### PR TITLE
修改了“珠峰博客”、“gulp”两篇文章中的笔误。

### DIFF
--- a/md/NODEJS/珠峰博客.md
+++ b/md/NODEJS/珠峰博客.md
@@ -235,7 +235,7 @@ module.exports = app;  导出app供 bin/www 使用
 
 ### 2.3 bin/www
 ```javascript
-!/usr/bin/env node  表明是 node 可执行文件。
+#!/usr/bin/env node  表明是 node 可执行文件。
 
 //引入我们上面app.js导出的app实例
 var app = require('../app');
@@ -746,7 +746,7 @@ url:"mongodb://123.57.143.189:27017/zhufengblog"
 ```javascript
 var mongoose = require('mongoose'),
 Schema = mongoose.Schema,
-models = require('./models');
+
 var settings = require('../settings');
 mongoose.connect(settings.url);
 mongoose.model('User', new Schema({

--- a/md/框架和库/gulp.md
+++ b/md/框架和库/gulp.md
@@ -242,11 +242,11 @@ gulp内部使用了`node-glob`模块来实现其文件匹配功能。我们可�
 <table>
 <tr><td>glob</td><td>匹配</td></tr>
 <tr><td>*</td><td>能匹配 a.js,x.y,abc,abc/,但不能匹配a/b.js</td></tr>
-<tr><td>\*.\*</td><td>a.js,style.css,a.b,x.y</td></tr>
-<tr><td>\*/\*/\*.js</td><td>能匹配 a/b/c.js,x/y/z.js,不能匹配a/b.js,a/b/c/d.js</td></tr>
-<tr><td>\*\*</td><td>能匹配 abc,a/b.js,a/b/c.js,x/y/z,x/y/z/a.b,能用来匹配所有的目录和文件</td></tr>
-<tr><td>a/\*\*/z</td><td>能匹配 a/z,a/b/z,a/b/c/z,a/d/g/h/j/k/z</td></tr>
-<tr><td>a/\*\*b/z</td><td>能匹配 a/b/z,a/sb/z,但不能匹配a/x/sb/z,因为只有单**单独出现才能匹配多级目录</td></tr>
+<tr><td>*.*</td><td>a.js,style.css,a.b,x.y</td></tr>
+<tr><td>*/*/*.js</td><td>能匹配 a/b/c.js,x/y/z.js,不能匹配a/b.js,a/b/c/d.js</td></tr>
+<tr><td>**</td><td>能匹配 abc,a/b.js,a/b/c.js,x/y/z,x/y/z/a.b,能用来匹配所有的目录和文件</td></tr>
+<tr><td>a/**/z</td><td>能匹配 a/z,a/b/z,a/b/c/z,a/d/g/h/j/k/z</td></tr>
+<tr><td>a/**b/z</td><td>能匹配 a/b/z,a/sb/z,但不能匹配a/x/sb/z,因为只有单**单独出现才能匹配多级目录</td></tr>
 <tr><td>?.js</td><td>能匹配 a.js,b.js,c.js</td></tr>
 <tr><td>a??</td><td>能匹配 a.b,abc,但不能匹配ab/,因为它不会匹配路径分隔符</td></tr>
 <tr><td>[xyz].js</td><td>只能匹配 x.js,y.js,z.js,不会匹配xy.js,xyz.js等,整个中括号只代表一个字符</td></tr>

--- a/md/框架和库/gulp.md
+++ b/md/框架和库/gulp.md
@@ -241,7 +241,7 @@ gulp内部使用了`node-glob`模块来实现其文件匹配功能。我们可�
 #### 8.2.2 glob示例
 <table>
 <tr><td>glob</td><td>匹配</td></tr>
-<tr><td>\*</td><td>能匹配 a.js,x.y,abc,abc/,但不能匹配a/b.js</td></tr>
+<tr><td>*</td><td>能匹配 a.js,x.y,abc,abc/,但不能匹配a/b.js</td></tr>
 <tr><td>\*.\*</td><td>a.js,style.css,a.b,x.y</td></tr>
 <tr><td>\*/\*/\*.js</td><td>能匹配 a/b/c.js,x/y/z.js,不能匹配a/b.js,a/b/c/d.js</td></tr>
 <tr><td>\*\*</td><td>能匹配 abc,a/b.js,a/b/c.js,x/y/z,x/y/z/a.b,能用来匹配所有的目录和文件</td></tr>


### PR DESCRIPTION
请老师审定
==========“珠峰博客一文中的修改部分”=========
1.bin/www.js文章最上部分的注释，应该加上“#”；
2. 2.4节中，删除了对于models模块的引用，因为并没有使用到这个模块，全文也没有提到这个模块。
请核实
=============“gulp一文中的修改部分”====================
8.2.2一节的示例中，*并不需要转移，原文进行了转移，反而造成了误解
